### PR TITLE
WPB-119 removed redundant font family google addition

### DIFF
--- a/controllers/lumavate_controller.go
+++ b/controllers/lumavate_controller.go
@@ -266,10 +266,6 @@ func (this *LumavateController) GetDynamicComponentsProperty(tag, name, classifi
 }
 
 func (this *LumavateController) InitBranding(instanceData *models.AppSettingsStruct){
-  instanceData.MainFontFamily = this.convertFontFamily(instanceData.MainFontFamily)
-  instanceData.SecondaryFontFamily = this.convertFontFamily(instanceData.SecondaryFontFamily)
-  instanceData.TertiaryFontFamily = this.convertFontFamily(instanceData.TertiaryFontFamily)
-
   if instanceData.BodyMaxWidth != 0 {
     instanceData.BodyMaxWidthStr = fmt.Sprintf("%vpx", instanceData.BodyMaxWidth)
   } else {
@@ -303,13 +299,6 @@ func (this *LumavateController) ContainsIonicLibrary(includes []string) bool{
   }
   return false
 
-}
-
-func (this *LumavateController) convertFontFamily(fontFamily string) string {
-  if !(strings.HasPrefix(fontFamily, "custom:") || strings.HasPrefix(fontFamily, "standard:") || strings.HasPrefix(fontFamily, "google:")) {
-    return "google:" + fontFamily
-  }
-  return fontFamily
 }
 
 func (this *LumavateController) initFontStyle(key string, fontStyle *models.FontStyleStruct) models.FontStyleDisplayStruct{


### PR DESCRIPTION
This is to clean up page builder and app builder font lay down. For some reason we were adding google: as a prefix in go but then immediately stripped that off in the template, so there is no point with this and I'm removing it so we can clean up the templates too.  This has to be committed first though so I can tag and update page-builder/app builder go-common versions